### PR TITLE
README: Update repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ and the program should also be visible in your launcher/application menu
 ## Building and running
 Download or clone the repo
 ```
-git clone https://github.com/phoneybadger/picker.git
-cd picker
+git clone https://github.com/ellie-commons/cherrypick.git
+cd cherrypick
 ```
 ### Build with Flatpak
 


### PR DESCRIPTION
I don't think the all of following appearance of `picker` should be updated to `cherrypick`, but README should point to the new URL at least.

```
ryo@b760m-host:~/work/tmp/cherrypick (ryonakano/readme-update-url)$ git grep -i picker | wc -l
225
ryo@b760m-host:~/work/tmp/cherrypick (ryonakano/readme-update-url)$
```
